### PR TITLE
Aggiornamento gruppo Secretary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
+/src/main/resources/log4j2.xml

--- a/pom.xml
+++ b/pom.xml
@@ -32,10 +32,45 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
+			<exclusions>
+				<exclusion>
+					<groupId>org.springframework.boot</groupId>
+					<artifactId>spring-boot-starter-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-log4j2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.lmax</groupId>
+			<artifactId>disruptor</artifactId>
+			<version>4.0.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.2.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.github.classgraph</groupId>
+			<artifactId>classgraph</artifactId>
+			<version>4.8.162</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>

--- a/src/main/java/it/dedagroup/project_cea/controller/AdministratorController.java
+++ b/src/main/java/it/dedagroup/project_cea/controller/AdministratorController.java
@@ -53,7 +53,7 @@ public class AdministratorController {
 	
 	//ENDPOINT DI INSERIMENTO DEL CONDOMINIO
 	@Operation(summary = "Inserimento <Condominium> nel database.", description = "Questo endpoint consente l'inserimento di un nuovo condominio.")
-	@ApiResponses(value = { 
+	@ApiResponses(value = {
 	    @ApiResponse(responseCode = "201", description = "Inserimento del condominio nel database avvenuto. Esempio di risposta: {'message':'Condominio inserito con successo'}"),
 	    @ApiResponse(responseCode = "400", description = "Errore nella richiesta. Possono verificarsi errori di validazione dei campi."),
 	    @ApiResponse(responseCode = "500", description = "Errore interno del server.")
@@ -65,7 +65,7 @@ public class AdministratorController {
 	
 	//ENDPOINT DI INSERIMENTO DELLA BOLLETTA
 	@Operation(summary = "Inserimento <Bill> nel database.", description = "Questo endpoint consente l'inserimento di un nuova bolletta.")
-	@ApiResponses(value = { 
+	@ApiResponses(value = {
 	    @ApiResponse(responseCode = "201", description = "Inserimento della bolletta nel database avvenuto. Esempio di risposta: {'message':'Bolletta inserita con successo'}"),
 	    @ApiResponse(responseCode = "400", description = "Errore nella richiesta. Possono verificarsi errori di validazione dei campi."),
 	    @ApiResponse(responseCode = "500", description = "Errore interno del server.")
@@ -78,7 +78,7 @@ public class AdministratorController {
 
     @PostMapping(CREATE_APARTMENT_PATH)
     @Operation(summary = "Inserimento <Apartment> nel database.", description = "Questo endpoint consente l'inserimento di un nuovo appartamento.")
-	@ApiResponses(value = { 
+	@ApiResponses(value = {
 	    @ApiResponse(responseCode = "201", description = "Inserimento dell' appartamento nel database avvenuto. Esempio di risposta: {'message':'Appartamento inserito con successo'}"),
 	    @ApiResponse(responseCode = "400", description = "Errore nella richiesta. Possono verificarsi errori di validazione dei campi."),
 	    @ApiResponse(responseCode = "500", description = "Errore interno del server.")

--- a/src/main/java/it/dedagroup/project_cea/controller/SecretaryController.java
+++ b/src/main/java/it/dedagroup/project_cea/controller/SecretaryController.java
@@ -7,9 +7,11 @@ import it.dedagroup.project_cea.model.Scan;
 import it.dedagroup.project_cea.model.Secretary;
 import it.dedagroup.project_cea.model.TypeOfIntervention;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -17,6 +19,7 @@ import java.util.List;
 
 import static it.dedagroup.project_cea.util.UtilPath.*;
 //TODO validate i request param e i pathvariable
+@Validated
 @RestController
 public class SecretaryController {
 	
@@ -24,7 +27,7 @@ public class SecretaryController {
 	SecretaryFacade secFac;
 	
 	@GetMapping(GET_ALL_BILLS_OF_CONDOMINIUM_PATH+"{idCondominium}")
-	public ResponseEntity<List<BillDTOResponse>> getAllBillsOfCondominium(@PathVariable long idCondominium){
+	public ResponseEntity<List<BillDTOResponse>> getAllBillsOfCondominium(@PathVariable @Min(value = 1, message = "min id input is 1") long idCondominium){
 		return ResponseEntity.status(HttpStatus.OK).body(secFac.getAllBillsOfCondominium(idCondominium));
 	}
 	
@@ -56,14 +59,14 @@ public class SecretaryController {
 		}
 	}
 
-	@PostMapping(ACCEPT_PENDING_INTERVENTION_PATH+"{idApartment}/{idIntervention}")
-	public ResponseEntity<InterventionDTOResponse> acceptPendingIntervention(@PathVariable long idApartment, @PathVariable long idIntervention){
-		return ResponseEntity.status(HttpStatus.ACCEPTED).body(secFac.acceptPendingIntervention(idApartment, idIntervention));
+	@PostMapping(ACCEPT_PENDING_INTERVENTION_PATH+"{idIntervention}")
+	public ResponseEntity<InterventionDTOResponse> acceptPendingIntervention(@PathVariable long idIntervention){
+		return ResponseEntity.status(HttpStatus.ACCEPTED).body(secFac.acceptPendingIntervention(idIntervention));
 	}
 
 	@GetMapping(LIST_OF_CONDOMINIUM_OF_TECHNICIAN_INTERVENTIONS_PATH+"{idTechnician}")
-		public ResponseEntity<List<CondominiumDtoResponse>> listOfCondominiumOfInterventionsOfTechnician(@PathVariable long idTechnician){
-		return ResponseEntity.status(HttpStatus.ACCEPTED).body(secFac.listaCondominiDiInterventiTecnico(idTechnician));
+		public ResponseEntity<List<CondominiumDtoResponse>> condominiumsWhereTechnicianDidInterventions(@PathVariable long idTechnician){
+		return ResponseEntity.status(HttpStatus.ACCEPTED).body(secFac.condominiumsWhereTechnicianDidInterventions(idTechnician));
 		}
 
 	//ritorna la lista di interventi in carico a un determinato tecnico,
@@ -80,7 +83,7 @@ public class SecretaryController {
 	}
 
 
-	//Da implementare, vedere facade per dettagli
+	//vedere facade per dettagli
 	//ritorna la lista di bollette del cliente che non sono state ancora pagate
 	@GetMapping(GET_ALL_UNPAID_BILLS_OF_CUSTOMER + "{idCustomer}")
 	public ResponseEntity<List<BillDTOResponse>> getAllUnpaidBillsOfCustomer(@PathVariable long idCustomer){
@@ -111,8 +114,18 @@ public class SecretaryController {
 		return ResponseEntity.status(HttpStatus.OK).body(secFac.getAllInterventionsSortedByDate());
 	}
 
-	@PostMapping("/secretary/updateIntervention")
+	@PostMapping(UPDATE_INTERVENTION)
 	public ResponseEntity<InterventionDTOResponse> updateIntervention(@Valid @RequestBody InterventionUpdateDTORequest request){
 		return ResponseEntity.status(HttpStatus.OK).body(secFac.editIntervention(request));
+	}
+
+	@GetMapping(GET_ALL_TECHNICIANS_AVAILABLE_IN_A_DATE + "{date}")
+	public ResponseEntity<List<TechnicianDTOResponse>> getAllTechniciansAvailableInADate(@PathVariable LocalDate date){
+		return ResponseEntity.status(HttpStatus.OK).body(secFac.getAllAvailableTechniciansInADate(date));
+	}
+
+	@GetMapping(GET_ALL_INTERVENTIONS_OF_DATE_OF_TECHNICIAN + "{idTechnician}/{date}")
+	public ResponseEntity<List<InterventionDTOResponse>> getInterventionsOfDateOfTechnician(@PathVariable long idTechnician, @PathVariable LocalDate date){
+		return ResponseEntity.status(HttpStatus.OK).body(secFac.getInterventionsOfDateOfTechnician(idTechnician, date));
 	}
 }

--- a/src/main/java/it/dedagroup/project_cea/dto/response/MessageDtoResponse.java
+++ b/src/main/java/it/dedagroup/project_cea/dto/response/MessageDtoResponse.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MessageDtoResponse {
-	private List<String> message = new ArrayList<>();
+	private List<String> message;
 	private int codice;
 	private Object request;
 	private LocalDateTime data;
@@ -23,8 +23,7 @@ public class MessageDtoResponse {
 	}
 	
 	public MessageDtoResponse(String errore, int codice, Object request, LocalDateTime data) {
-		message.add(errore);
-		this.codice = codice;
+		this(List.of(errore),codice);
 		this.request = request;
 		this.data = data;
 	}

--- a/src/main/java/it/dedagroup/project_cea/dto/response/TechnicianDTOResponse.java
+++ b/src/main/java/it/dedagroup/project_cea/dto/response/TechnicianDTOResponse.java
@@ -13,8 +13,8 @@ public class TechnicianDTOResponse {
 	
 	private List<Intervention> interventions;
 	
-	private long id_secretary;
-	
+	private List<Long> id_secretaries; //cambiato da singola segretaria a multiple, perchè  un tecnico può, tramite diversi interventi, avere associate doverse segretarie
+
 	private int workLoad = 5;
 	
 	private String name;

--- a/src/main/java/it/dedagroup/project_cea/exception/model/EmptyListException.java
+++ b/src/main/java/it/dedagroup/project_cea/exception/model/EmptyListException.java
@@ -1,0 +1,24 @@
+package it.dedagroup.project_cea.exception.model;
+
+import lombok.Data;
+import lombok.Getter;
+
+@Getter
+public class EmptyListException extends RuntimeException{
+
+    private static final long serialVersionUID = 1L;
+    private Object request;
+
+    public EmptyListException(Object request, String msg) {
+        super(msg);
+        this.request = request;
+    }
+
+    public EmptyListException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public EmptyListException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/it/dedagroup/project_cea/exception/model/ExceptionHandlerCustom.java
+++ b/src/main/java/it/dedagroup/project_cea/exception/model/ExceptionHandlerCustom.java
@@ -50,6 +50,13 @@ public class ExceptionHandlerCustom {
 		return ResponseEntity.status(HttpStatus.NOT_FOUND).body(m);
 	}
 
+	@ExceptionHandler(EmptyListException.class)
+	public ResponseEntity<MessageDtoResponse> emptyList(EmptyListException e){
+		MessageDtoResponse m = new MessageDtoResponse(e.getMessage(), HttpStatus.BAD_REQUEST.value(), e.getRequest(), LocalDateTime.now());
+		System.out.println(m);
+	return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(m);
+	}
+
 	//ExceptionHandler per gestire le ConstraintViolations(PathVariable e RequestParam)
 	@ExceptionHandler(ConstraintViolationException.class)
 	@ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -62,5 +69,7 @@ public class ExceptionHandlerCustom {
 		}
 		return error;
 	}
+
+
 
 }

--- a/src/main/java/it/dedagroup/project_cea/mapper/TechnicianMapper.java
+++ b/src/main/java/it/dedagroup/project_cea/mapper/TechnicianMapper.java
@@ -2,6 +2,7 @@ package it.dedagroup.project_cea.mapper;
 
 import it.dedagroup.project_cea.dto.response.InterventionDTOResponse;
 import it.dedagroup.project_cea.model.Intervention;
+import it.dedagroup.project_cea.model.Secretary;
 import org.springframework.stereotype.Component;
 
 import it.dedagroup.project_cea.dto.request.TechnicianDTORequest;
@@ -18,6 +19,12 @@ public class TechnicianMapper {
 		TechnicianDTOResponse tech = new TechnicianDTOResponse();
 		tech.setId(t.getId());
 		tech.setName(t.getName());
+		tech.setWorkLoad(t.getMaxWorkload()); //aggiunto
+		List<Long> idSecretariesList = t.getInterventions().stream()
+				.map(Intervention::getSecretary).map(Secretary::getId)
+				.distinct()
+				.toList();
+		tech.setId_secretaries(idSecretariesList);
 		tech.setSurname(t.getSurname());
 		tech.setUsername(t.getUsername());
 		tech.setPassword(t.getPassword());

--- a/src/main/java/it/dedagroup/project_cea/repository/ApartmentRepository.java
+++ b/src/main/java/it/dedagroup/project_cea/repository/ApartmentRepository.java
@@ -16,6 +16,8 @@ public interface ApartmentRepository extends JpaRepository<Apartment, Long> {
 	public List<Apartment> findAllApartmentByCustomerId(long id_customer);
 	public Optional<Apartment> findApartmentByCustomer_id(long id_user);
 
+	public Optional<Apartment> findByIdAndIsAvailableTrue(long idApartment);
+
 	//dovrebbe andarsi a prendere solamente la lista degli appartamenti abitati
 	//public List<Apartment> findAllByCondominium_IdAndCustomerIsNotEmpty(long condominiumId);
 }

--- a/src/main/java/it/dedagroup/project_cea/repository/CondominiumRepository.java
+++ b/src/main/java/it/dedagroup/project_cea/repository/CondominiumRepository.java
@@ -1,6 +1,7 @@
 package it.dedagroup.project_cea.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,8 +17,5 @@ public interface CondominiumRepository extends JpaRepository<Condominium, Long> 
     @Query("SELECT c FROM Condominium co JOIN co.apartments a JOIN a.customer c WHERE co.id = :condominiumId")
     public List<Customer> findCustomersByCondominiumId(long condominiumId);
 
-
-
-
-
+    public Optional<Condominium> findByIdAndIsAvailableTrue(long idCondominium);
 }

--- a/src/main/java/it/dedagroup/project_cea/repository/CustomerRepository.java
+++ b/src/main/java/it/dedagroup/project_cea/repository/CustomerRepository.java
@@ -13,7 +13,7 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
 	public Optional<Customer> findCustomerByTaxCode(String taxCode);
 	public List<Customer> findAllCustomerByNameAndSurname(String name, String surname);
 	public Optional<Customer> findCustomerByApartments_Id(long apartment_id);
-
+	public Optional<Customer> findByIdAndIsAvailableTrue(long idCustomer);
 
 }
 

--- a/src/main/java/it/dedagroup/project_cea/repository/InterventionRepository.java
+++ b/src/main/java/it/dedagroup/project_cea/repository/InterventionRepository.java
@@ -2,14 +2,26 @@ package it.dedagroup.project_cea.repository;
 
 import java.util.List;
 import java.util.Optional;
-
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import it.dedagroup.project_cea.model.TypeOfIntervention;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import java.time.LocalDate;
 import it.dedagroup.project_cea.model.Intervention;
 
 public interface InterventionRepository extends JpaRepository<Intervention, Long> {
 	public List<Intervention> findAllByTechnician_Id(long idTechnician);
 	public List<Intervention> findAllByType(TypeOfIntervention type);
 	public Optional<List<Intervention>> findAllByApartment_Customer_Id(long idCustomer);
+/*
+	@Query("SELECT t.interventions FROM Technician t " +
+			"INNER JOIN t.interventions i " +
+			"WHERE t.id = :technicianId " +
+			"AND i.interventionDate = :date")
+	List<Intervention> findInterventionsByTechnicianAndDate(@Param("technicianId") Long technicianId, @Param("date") LocalDate date);
+
+ */
+	public List<Intervention> findByTechnician_IdAndInterventionDate(long idTechnician, LocalDate date);
+	public Optional<Intervention> findByIdAndIsAvailableTrue(long idIntervention);
 }
+

--- a/src/main/java/it/dedagroup/project_cea/repository/SecretaryRepository.java
+++ b/src/main/java/it/dedagroup/project_cea/repository/SecretaryRepository.java
@@ -7,5 +7,6 @@ import it.dedagroup.project_cea.model.Secretary;
 import java.util.Optional;
 
 public interface SecretaryRepository extends JpaRepository<Secretary, Long> {
-    public List<Secretary> findAllByIntervention_Technician_Id(long idTechnician);
+    public List<Secretary> findAllByIntervention_Technician_IdAndIsAvailableTrue(long idTechnician);
+    public Optional<Secretary> findByIdAndIsAvailableTrue(long idSecretary);
 }

--- a/src/main/java/it/dedagroup/project_cea/repository/TechnicianRepository.java
+++ b/src/main/java/it/dedagroup/project_cea/repository/TechnicianRepository.java
@@ -18,5 +18,7 @@ public interface TechnicianRepository extends JpaRepository<Technician, Long> {
 //	public Optional<List<Technician>> findFreeTechnicians(LocalDate x);
 	Optional<Technician> findByInterventions_Id(Long id);
 	List<Technician> findAllByInterventions_Secretary_id(long idSec);
-	Optional<Technician> findByNameAndSurname(String name, String surname);
+	Optional<Technician> findByNameAndSurnameAndIsAvailableTrue(String name, String surname);
+	List<Technician> findAllByIsAvailableTrue();
+	Optional<Technician> findByIdAndIsAvailableTrue(long idTechnician);
 }

--- a/src/main/java/it/dedagroup/project_cea/service/def/ApartmentServiceDef.java
+++ b/src/main/java/it/dedagroup/project_cea/service/def/ApartmentServiceDef.java
@@ -16,4 +16,5 @@ public interface ApartmentServiceDef {
 	public Apartment findApartmentByUnitNumberAndFloorNumberAndCondominiumId(int unit_number, int floor_number, long id_condominium);
 	public List<Apartment> findAllApartmentByCondominiumId(long id_condominium);
 	public List<Apartment> findAllApartmentByCustomerId(long id_customer);
+	public Apartment findByIdAndIsAvailableTrue(long idApartment);
 }

--- a/src/main/java/it/dedagroup/project_cea/service/def/CondominiumServiceDef.java
+++ b/src/main/java/it/dedagroup/project_cea/service/def/CondominiumServiceDef.java
@@ -15,4 +15,5 @@ public interface CondominiumServiceDef {
 	public Condominium findCondominiumByApartment_id(long apartmentId);
 	List<Customer> getConsumersByCondominiumId(long id_condominium);
 
+	public Condominium findByIdAndIsAvailableTrue(long idCondominium);
 }

--- a/src/main/java/it/dedagroup/project_cea/service/def/CustomerServiceDef.java
+++ b/src/main/java/it/dedagroup/project_cea/service/def/CustomerServiceDef.java
@@ -2,6 +2,7 @@ package it.dedagroup.project_cea.service.def;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import it.dedagroup.project_cea.model.Bill;
 import it.dedagroup.project_cea.model.Customer;
@@ -24,7 +25,7 @@ public interface CustomerServiceDef {
 	public Customer findCustomerByTaxCode(String taxCode);
 	public List<Customer> findAllCustomerByNameAndSurname(String name, String surname);
 	public Customer findCustomerByApartments_Id(long id_apartment);
-	
+	public Customer findByIdAndIsAvailableTrue(long idCustomer);
 }
 
 //metodi del Customer vuoti, li definiamo nell implementation

--- a/src/main/java/it/dedagroup/project_cea/service/def/InterventionServiceDef.java
+++ b/src/main/java/it/dedagroup/project_cea/service/def/InterventionServiceDef.java
@@ -1,5 +1,6 @@
 package it.dedagroup.project_cea.service.def;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,4 +17,6 @@ public interface InterventionServiceDef {
 	public List<Intervention> findAll();
 	void save(Intervention interv);
 	public List<Intervention> findAllByApartment_Customer_Id(long idCustomer);
+	List<Intervention> findByTechnician_IdAndInterventionDate(long idTechnician, LocalDate date);
+	Intervention findByIdAndIsAvailableTrue(long idIntervention);
 }

--- a/src/main/java/it/dedagroup/project_cea/service/def/SecretaryServiceDef.java
+++ b/src/main/java/it/dedagroup/project_cea/service/def/SecretaryServiceDef.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface SecretaryServiceDef {
-    public List<Secretary> findAllByIntervention_Technician_Id(long idTechnician);
+    public List<Secretary> findAllByIntervention_Technician_IdAndIsAvailableTrue(long idTechnician);
     public Secretary findById(long idSecretary);
+    public Secretary findByIdAndIsAvailableTrue(long idSecretary);
 }

--- a/src/main/java/it/dedagroup/project_cea/service/def/TechnicianServiceDef.java
+++ b/src/main/java/it/dedagroup/project_cea/service/def/TechnicianServiceDef.java
@@ -19,5 +19,7 @@ public interface TechnicianServiceDef {
 	List<Technician> findFree();
 	Technician findByInterventionId(long idIntervention);
 	List<Technician> findAllByInterventions_Secretary_id(long idSec);
-	Technician findByNameAndSurname(String name, String surname);
+	Technician findByNameAndSurnameAndIsAvailableTrue(String name, String surname);
+	List<Technician> findAllByIsAvailableTrue();
+	Technician findByIdAndIsAvailableTrue(long idTechnician);
 }

--- a/src/main/java/it/dedagroup/project_cea/service/impl/ApartmentServiceImpl.java
+++ b/src/main/java/it/dedagroup/project_cea/service/impl/ApartmentServiceImpl.java
@@ -3,12 +3,14 @@ package it.dedagroup.project_cea.service.impl;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 import it.dedagroup.project_cea.exception.model.NotValidDataException;
 import it.dedagroup.project_cea.model.Apartment;
 import it.dedagroup.project_cea.repository.ApartmentRepository;
 import it.dedagroup.project_cea.service.def.ApartmentServiceDef;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 public class ApartmentServiceImpl implements ApartmentServiceDef {
@@ -75,5 +77,10 @@ public class ApartmentServiceImpl implements ApartmentServiceDef {
 	@Override
 	public List<Apartment> findAllApartmentByCustomerId(long id_customer) {
 		return repo.findAllApartmentByCustomerId(id_customer);
+	}
+
+	@Override
+	public Apartment findByIdAndIsAvailableTrue(long idApartment) {
+		return repo.findByIdAndIsAvailableTrue(idApartment).orElseThrow(()-> new ResponseStatusException(HttpStatus.BAD_REQUEST, "No apartment found with id " + idApartment + " or apartment set to unavailable"));
 	}
 }

--- a/src/main/java/it/dedagroup/project_cea/service/impl/CondominiumServiceImpl.java
+++ b/src/main/java/it/dedagroup/project_cea/service/impl/CondominiumServiceImpl.java
@@ -56,7 +56,10 @@ public class CondominiumServiceImpl implements CondominiumServiceDef {
 				.collect(Collectors.toList());
 	}
 
-
+	@Override
+	public Condominium findByIdAndIsAvailableTrue(long idCondominium) {
+		return condRepo.findByIdAndIsAvailableTrue(idCondominium).orElseThrow(()-> new ResponseStatusException(HttpStatus.BAD_REQUEST, "No condominium found with this id or unavailable"));
+	}
 
 
 }

--- a/src/main/java/it/dedagroup/project_cea/service/impl/CustomerServiceImpl.java
+++ b/src/main/java/it/dedagroup/project_cea/service/impl/CustomerServiceImpl.java
@@ -2,6 +2,8 @@ package it.dedagroup.project_cea.service.impl;
 
 import java.time.LocalDate;
 import java.util.List;
+
+import it.dedagroup.project_cea.exception.model.UserNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import it.dedagroup.project_cea.exception.model.NotValidDataException;
@@ -113,5 +115,10 @@ public class CustomerServiceImpl implements CustomerServiceDef{
 	public Customer findCustomerByApartments_Id(long id_apartment) {
 		return customerRepo.findCustomerByApartments_Id(id_apartment)
 				.orElseThrow(() -> new NotValidDataException("Customer not found with Apartment's id: "+id_apartment));
+	}
+
+	@Override
+	public Customer findByIdAndIsAvailableTrue(long idCustomer) {
+		return customerRepo.findByIdAndIsAvailableTrue(idCustomer).orElseThrow(()-> new UserNotFoundException("No customer found with this id or unavailable"));
 	}
 }

--- a/src/main/java/it/dedagroup/project_cea/service/impl/InterventionServiceImpl.java
+++ b/src/main/java/it/dedagroup/project_cea/service/impl/InterventionServiceImpl.java
@@ -1,7 +1,9 @@
 package it.dedagroup.project_cea.service.impl;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import it.dedagroup.project_cea.exception.model.EmptyListException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -58,6 +60,17 @@ public class InterventionServiceImpl implements InterventionServiceDef {
 	@Override
 	public List<Intervention> findAllByApartment_Customer_Id(long idCustomer) {
 		return intervRepo.findAllByApartment_Customer_Id(idCustomer).orElseThrow(()-> new ResponseStatusException(HttpStatus.NO_CONTENT, "No interventions found for this customer"));
+	}
+
+	@Override
+	public List<Intervention> findByTechnician_IdAndInterventionDate(long idTechnician, LocalDate date) {
+		return intervRepo.findByTechnician_IdAndInterventionDate(idTechnician, date);
+	}
+
+	@Override
+	public Intervention findByIdAndIsAvailableTrue(long idIntervention) {
+		return intervRepo.findByIdAndIsAvailableTrue(idIntervention)
+				.orElseThrow(()-> new ResponseStatusException(HttpStatus.BAD_REQUEST, "No interventions found with this id or intervention is set to unavailable"));
 	}
 
 	@Override

--- a/src/main/java/it/dedagroup/project_cea/service/impl/ScanServiceImpl.java
+++ b/src/main/java/it/dedagroup/project_cea/service/impl/ScanServiceImpl.java
@@ -35,8 +35,8 @@ public class ScanServiceImpl implements ScanServiceDef {
 	public void save(Scan scan) {
 		scanRepo.save(scan);
 	}
-	
-	
+
+
 	@Override
 	public void removeScan(Scan scan) {
 		scanRepo.findById(scan.getId()).orElseThrow(()->new ScanNotFoundException("Scan not found"));

--- a/src/main/java/it/dedagroup/project_cea/service/impl/SecretaryServiceImpl.java
+++ b/src/main/java/it/dedagroup/project_cea/service/impl/SecretaryServiceImpl.java
@@ -19,12 +19,17 @@ public class SecretaryServiceImpl implements SecretaryServiceDef {
     SecretaryRepository secRepo;
 
     @Override
-    public List<Secretary> findAllByIntervention_Technician_Id(long idTechnician) {
-        return secRepo.findAllByIntervention_Technician_Id(idTechnician);
+    public List<Secretary> findAllByIntervention_Technician_IdAndIsAvailableTrue(long idTechnician) {
+        return secRepo.findAllByIntervention_Technician_IdAndIsAvailableTrue(idTechnician);
     }
 
     @Override
     public Secretary findById(long idSecretary) {
         return secRepo.findById(idSecretary).orElseThrow(()-> new UserNotFoundException("No secretary found with id " + idSecretary));
+    }
+
+    @Override
+    public Secretary findByIdAndIsAvailableTrue(long idSecretary) {
+        return secRepo.findByIdAndIsAvailableTrue(idSecretary).orElseThrow(()-> new UserNotFoundException("No secretary found with id " + idSecretary + " or secretary unavailable"));
     }
 }

--- a/src/main/java/it/dedagroup/project_cea/service/impl/TechnicianServiceImpl.java
+++ b/src/main/java/it/dedagroup/project_cea/service/impl/TechnicianServiceImpl.java
@@ -2,6 +2,7 @@ package it.dedagroup.project_cea.service.impl;
 
 import java.util.List;
 
+import it.dedagroup.project_cea.exception.model.EmptyListException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -47,8 +48,19 @@ public class TechnicianServiceImpl implements TechnicianServiceDef{
 	}
 
 	@Override
-	public Technician findByNameAndSurname(String name, String surname) {
-		return techRepo.findByNameAndSurname(name, surname).orElseThrow(()-> new UserNotFoundException("Technician not found with name " + name + " and surname " + surname));
+	public Technician findByNameAndSurnameAndIsAvailableTrue(String name, String surname) {
+		return techRepo.findByNameAndSurnameAndIsAvailableTrue(name, surname).orElseThrow(()-> new UserNotFoundException("Technician not found with name " + name + " and surname " + surname));
+	}
+
+	@Override
+	public List<Technician> findAllByIsAvailableTrue() {
+		return techRepo.findAllByIsAvailableTrue();
+	}
+
+	@Override
+	public Technician findByIdAndIsAvailableTrue(long idTechnician) {
+		return techRepo.findByIdAndIsAvailableTrue(idTechnician)
+				.orElseThrow(()-> new ResponseStatusException(HttpStatus.BAD_REQUEST, "No technicians found with this id or technician is set to unavailable"));
 	}
 
 	@Override

--- a/src/main/java/it/dedagroup/project_cea/util/UtilPath.java
+++ b/src/main/java/it/dedagroup/project_cea/util/UtilPath.java
@@ -60,4 +60,7 @@ public class UtilPath {
     public static final String GET_SECRETARIES_ASSOCIATED_TO_TECHNICIAN = SECRETARY_PATH + "/getSecretariesOfTechnician/";
     public static final String CHANGE_TECHNICIAN_ASSIGNED_TO_INTERVENTION = SECRETARY_PATH + "/changeTechnicianAssignedToIntervention/";
     public static final String GET_ALL_INTERVENTIONS_SORTED_BY_DATE = SECRETARY_PATH + "/getAllInterventionsSortedByDate";
+    public static final String UPDATE_INTERVENTION = SECRETARY_PATH + "/updateIntervention";
+    public static final String GET_ALL_TECHNICIANS_AVAILABLE_IN_A_DATE = SECRETARY_PATH + "/getAllTechniciansAvailableInADate/";
+    public static final String GET_ALL_INTERVENTIONS_OF_DATE_OF_TECHNICIAN = SECRETARY_PATH + "/interventionsOfDateOfTechnician/";
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,5 +19,11 @@ spring.h2.console.path=/consoleDB
 
 spring.jpa.defer-datasource-initialization=true
 
+server.error.include-message=always
+
+#swagger
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/api-guide
+
 
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -10,6 +10,9 @@ VALUES ('Stefano', 'Ronci', 'stefRon', 'abc123_!', '00133', 1, TRUE);
 INSERT INTO customer (name, surname, username, password, tax_code, role, is_available)
 VALUES ('Nicolò', 'Rambo', 'nicRambo', 'ncRamb99', '00140', 1, TRUE);
 
+INSERT INTO customer (name, surname, username, password, tax_code, role, is_available)
+VALUES ('Nome', 'Cognome', 'test', 'test999!=', '00141111', 1, TRUE);
+
 -- Inserimento degli amministratori
 INSERT INTO administrator (is_available, role, name, surname, username, password)
 VALUES (TRUE, 0, 'Luca', 'Rossi', 'lRossiAdmin', 'aaa90_!');
@@ -20,6 +23,9 @@ VALUES (TRUE, 'via Kant 11', 1);
 
 INSERT INTO condominium (is_available, address, administrator_id)
 VALUES (TRUE, 'via Nazionale 111', 1);
+
+INSERT INTO condominium (is_available, address, administrator_id)
+VALUES (TRUE, 'via Pacello 123', 1);
 
 -- Inserimento degli appartamenti
 INSERT INTO apartment (floor_number, is_available, unit_number, condominium_id, customer_id)
@@ -92,11 +98,11 @@ INSERT INTO bill (cost, payment_day, delivering_Day, is_available, scan_id)
 VALUES (200, null, '2023-03-15', TRUE, 4);
 
 -- Inserimento dei tecnici
-INSERT INTO technician (is_available, workload, role, name, surname, username, password)
-VALUES (TRUE, 0, 3, 'Edwar', 'Azzaro', 'hacker', '123456ee!');
+INSERT INTO technician (is_available, max_workload, role, name, surname, username, password)
+VALUES (TRUE, 5, 3, 'Edwar', 'Azzaro', 'hacker', '123456ee!');
 
-INSERT INTO technician (is_available, workload, role, name, surname, username, password)
-VALUES (TRUE, 0, 3, 'Luigi', 'Cannizzaro', 'LCanniz', '6789aaa_!');
+INSERT INTO technician (is_available, max_workload, role, name, surname, username, password)
+VALUES (TRUE, 5, 3, 'Luigi', 'Cannizzaro', 'LCanniz', '6789aaa_!');
 
 INSERT INTO technician (is_available, workload, role, name, surname, username, password)
 VALUES (TRUE, 0, 3, 'Marco', 'Neri', 'mNeri', '0012abc_?');
@@ -110,12 +116,18 @@ VALUES (TRUE, 2, 'Lisa', 'Verdi', 'liv00', 'liv_00_!');
 
 -- Inserimento delle operazioni di intervento
 INSERT INTO intervention (is_available, intervention_date, status, type, apartment_id, secretary_id, technician_id)
-VALUES (TRUE, '2023-12-16', 3, 0, 1, 1, 1);
-@@ -79,4 +122,13 @@ INSERT INTO intervention (is_available, intervention_date, status, type, apartme
+VALUES (false, '2023-12-16', 3, 0, 1, 1, 1);
+
+INSERT INTO intervention (is_available, intervention_date, status, type, apartment_id, secretary_id, technician_id)
+VALUES (TRUE, '2023-12-15', 1, 1, 2, 1, 1);
+
+INSERT INTO intervention (is_available, intervention_date, status, type, apartment_id, secretary_id, technician_id)
+VALUES (TRUE, '2023-12-14', 2, 0, 1, 1, 1);
+
+INSERT INTO intervention (is_available, intervention_date, status, type, apartment_id, secretary_id, technician_id)
 VALUES (TRUE, '2023-12-19', 2, 0, 2, 1, 1);
 
 INSERT INTO intervention (is_available, intervention_date, status, type, apartment_id, secretary_id, technician_id)
-VALUES (TRUE, '2023-12-20', 2, 1, 2, 1, 1);
 VALUES (TRUE, '2023-12-20', 2, 1, 2, 1, 2);
 
 INSERT INTO intervention (is_available, intervention_date, status, type, apartment_id, secretary_id, technician_id)
@@ -126,3 +138,18 @@ VALUES (TRUE, '2023-09-27', 0, 1, 2, 2, 2);
 
 INSERT INTO intervention (is_available, intervention_date, status, type, apartment_id, secretary_id, technician_id)
 VALUES (TRUE, '2023-11-27', 2, 1, 2, 2, 2);
+
+INSERT INTO intervention (is_available, intervention_date, status, type, apartment_id, secretary_id, technician_id)
+VALUES (TRUE, '2023-11-01', 2, 1, 1, 2, 1);
+
+INSERT INTO intervention (is_available, intervention_date, status, type, apartment_id, secretary_id, technician_id)
+VALUES (TRUE, '2023-11-01', 2, 1, 1, 2, 1);
+
+INSERT INTO intervention (is_available, intervention_date, status, type, apartment_id, secretary_id, technician_id)
+VALUES (TRUE, '2023-11-01', 2, 1, 3, 2, 1);
+INSERT INTO intervention (is_available, intervention_date, status, type, apartment_id, secretary_id, technician_id)
+VALUES (TRUE, '2023-11-01', 2, 1, 2, 2, 1);
+INSERT INTO intervention (is_available, intervention_date, status, type, apartment_id, secretary_id, technician_id)
+VALUES (TRUE, '2023-11-01', 2, 1, 2, 2, 1);
+INSERT INTO intervention (is_available, intervention_date, status, type, apartment_id, secretary_id, technician_id)
+VALUES (TRUE, '2023-11-01', 2, 1, 3, 2, 2);


### PR DESCRIPTION
Aggiornamento gruppo Secretary. Sostituite nel facade le chiamate a findById o findAll con findByIdAndIsAvailableTrue e findAllByIsAvailable true, in modo da non andare ad agire su istanze di oggetti "cancellati". Inoltre ora i metodi che assegnano/modificano un tecnico relativo a un intervento, tengono conto della sua quota di lavoro giornaliera, impedendo l'assegnazione se essa è già stata raggiunta.